### PR TITLE
es5 jshint syntax 

### DIFF
--- a/lib/screw_server/jshint_suite.rb
+++ b/lib/screw_server/jshint_suite.rb
@@ -10,6 +10,7 @@ module ScrewServer
       "immed" => true,
       "newcap" => true,
       "undef" => true,
+      "es5" => true,
     }
 
     attr_accessor :name, :file_list, :options


### PR DESCRIPTION
This solution add support es5 sintax to ignore jshint error get/set syntax in es5
![screenshot 2015-06-25 17 29 42](https://cloud.githubusercontent.com/assets/1594996/8358309/cbfdb89e-1b5f-11e5-9186-17a30292915d.png)
